### PR TITLE
fixes #17: use "is not undefined" instead of "was provided" for depth

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ contributors: Brian Terlson
     1. Let _O_ be ? ToObject(*this* value).
     1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
     1. Let _depthNum_ be 1.
-    1. If _depth_ was provided, then
+    1. If _depth_ is not *undefined*, then
       1. Set _depthNum_ to ? ToInteger(_depth_). 
     1. Perform ? FlattenIntoArray(_A_, _O_, 0, _depthNum_).
     1. Return _A_.


### PR DESCRIPTION
Fixes #17.