### PR TITLE
Pass `sourceLen` into `FlattenIntoArray` so that it can be retrieved prior to array creation

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -18,8 +18,9 @@ contributors: Brian Terlson
     1. Let _O_ be ? ToObject(*this* value).
     1. If IsCallable(_callbackfn_) is *false*, throw a *TypeError* exception.
     1. If _thisArg_ was supplied, let _T_ be _thisArg_; else let _T_ be *undefined*.
+    1. Let _sourceLen_ be ? ToLength(? Get(_O_, `"length"`)).
     1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
-    1. Perform ? FlattenIntoArray(_A_, _O_, 0, 1, _callbackFn_, _T_).
+    1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, 1, _callbackFn_, _T_).
     1. Return _A_.
   </emu-alg>
 </emu-clause>
@@ -28,21 +29,21 @@ contributors: Brian Terlson
   <p>When the `flatten` method is called with zero or one arguments, the following steps are taken:</p>
   <emu-alg>
     1. Let _O_ be ? ToObject(*this* value).
-    1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
     1. Let _depthNum_ be 1.
     1. If _depth_ is not *undefined*, then
-      1. Set _depthNum_ to ? ToInteger(_depth_). 
-    1. Perform ? FlattenIntoArray(_A_, _O_, 0, _depthNum_).
+      1. Set _depthNum_ to ? ToInteger(_depth_).
+    1. Let _sourceLen_ be ? ToLength(? Get(_O_, `"length"`)).
+    1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
+    1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, _depthNum_).
     1. Return _A_.
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-FlattenIntoArray" aoid=FlattenIntoArray>
-  <h1>FlattenIntoArray(_target_, _source_, _start_, _depth_ [ , _mapperFunction_, _thisArg_ ])</h1>
+<emu-clause id="sec-FlattenIntoArray" aoid="FlattenIntoArray">
+  <h1>FlattenIntoArray(_target_, _source_, _sourceLen_, _start_, _depth_ [ , _mapperFunction_, _thisArg_ ])</h1>
   <emu-alg>
     1. Let _targetIndex_ be _start_.
     1. Let _sourceIndex_ be 0.
-    1. Let _sourceLen_ be ? ToLength(? Get(_source_, `"length"`)).
     1. Repeat, while _sourceIndex_ &lt; _sourceLen_
       1. Let _P_ be ! ToString(_sourceIndex_).
       1. Let _exists_ be ? HasProperty(_source_, _P_).
@@ -52,7 +53,8 @@ contributors: Brian Terlson
           1. Set _element_ to ? Call(_mapperFunction_, _thisArg_ , &laquo; _element_, _sourceIndex_, _target_ &raquo;).
         1. Let _spreadable_ be ? IsConcatSpreadable(_element_).
         1. If _spreadable_ is *true* and _depth_ &gt; 0, then
-          1. Let _nextIndex_ be ? FlattenIntoArray(_target_, _element_, _targetIndex_, _depth_ - 1).
+          1. Let _elementLen_ be ? ToLength(? Get(_element_, `"length"`)).
+          1. Let _nextIndex_ be ? FlattenIntoArray(_target_, _element_, _elementLen_, _targetIndex_, _depth_ - 1).
           1. Set _targetIndex_ to _nextIndex_ - 1.
         1. Else,
           1. If _targetIndex_ &ge; 2<sup>53</sup>-1, throw a *TypeError* exception.


### PR DESCRIPTION
Fixes #1.

 - I chose the ordering for `Let _sourceLen_ be` based on “validate arguments first, then validate argument properties”