### PR TITLE
FlattenIntoArray: ensure `thisArg` is present or undefined

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -50,6 +50,7 @@ contributors: Michael Ficarra and Brian Terlson
       1. If _exists_ is *true*, then
         1. Let _element_ be ? Get(_source_, _P_).
         1. If _mapperFunction_ is present, then
+          1. Assert: _thisArg_ is present.
           1. Set _element_ to ? Call(_mapperFunction_, _thisArg_ , &laquo; _element_, _sourceIndex_, _original_ &raquo;).
         1. Let _spreadable_ be ? IsArray(_element_).
         1. If _spreadable_ is *true* and _depth_ &gt; 0, then


### PR DESCRIPTION
Personally I'd prefer all the "is present" language be removed, but I'm not sure if it's necessary on the default args. If it is, then this change is needed; if it's not, then all the checks should be against `undefined`, not testing presence.