### PR TITLE
Replace spreadable with isArray

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -54,8 +54,8 @@ contributors: Michael Ficarra and Brian Terlson
         1. If _mapperFunction_ is present, then
           1. Assert: _thisArg_ is present.
           1. Set _element_ to ? Call(_mapperFunction_, _thisArg_ , &laquo; _element_, _sourceIndex_, _original_ &raquo;).
-        1. Let _spreadable_ be ? IsArray(_element_).
-        1. If _spreadable_ is *true* and _depth_ &gt; 0, then
+        1. Let _isArray_ be ? IsArray(_element_).
+        1. If _isArray_ is *true* and _depth_ &gt; 0, then
           1. Let _elementLen_ be ? ToLength(? Get(_element_, `"length"`)).
           1. Let _nextIndex_ be ? FlattenIntoArray(_target_, _original_, _element_, _elementLen_, _targetIndex_, _depth_ - 1).
           1. Set _targetIndex_ to _nextIndex_ - 1.


### PR DESCRIPTION
Things like strings are spreadable, but `IsArray(_element_)` returns false for these. [Other methods](https://tc39.github.io/ecma262/#sec-arrayspeciescreate) use `isArray` to store the return value of `IsArray`.