### PR TITLE
rename flatten to smoosh

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -1,5 +1,5 @@
 <pre class=metadata>
-title: Array.prototype.flatMap &amp; Array.prototype.flatten
+title: Array.prototype.flatMap &amp; Array.prototype.smoosh
 toc: false
 stage: 3
 contributors: Michael Ficarra and Brian Terlson
@@ -7,8 +7,8 @@ contributors: Michael Ficarra and Brian Terlson
 
 <emu-intro id="intro">
   <h1>Introduction</h1>
-  <p>`Array.prototype.flatten` returns a new array with all sub-array elements concatted into it recursively up to the specified depth.</p>
-  <p>`Array.prototype.flatMap` first maps each element using a mapping function, then flattens the result into a new array. It is identical to a map followed by a flatten of depth 1, but flatMap is quite often useful and merging both into one method is slightly more efficient.</p>
+  <p>`Array.prototype.smoosh` returns a new array with all sub-array elements concatted into it recursively up to the specified depth.</p>
+  <p>`Array.prototype.flatMap` first maps each element using a mapping function, then flattens the result into a new array. It is identical to a map followed by a smoosh of depth 1, but flatMap is quite often useful and merging both into one method is slightly more efficient.</p>
 </emu-intro>
 
 <emu-clause id="sec-Array.prototype.flatMap">
@@ -24,9 +24,9 @@ contributors: Michael Ficarra and Brian Terlson
     1. Return _A_.
   </emu-alg>
 </emu-clause>
-<emu-clause id="sec-Array.prototype.flatten">
-  <h1>Array.prototype.flatten( [ _depth_ ] )</h1>
-  <p>When the `flatten` method is called with zero or one arguments, the following steps are taken:</p>
+<emu-clause id="sec-Array.prototype.smoosh">
+  <h1>Array.prototype.smoosh( [ _depth_ ] )</h1>
+  <p>When the `smoosh` method is called with zero or one arguments, the following steps are taken:</p>
   <emu-alg>
     1. Let _O_ be ? ToObject(*this* value).
     1. Let _sourceLen_ be ? ToLength(? Get(_O_, `"length"`)).


### PR DESCRIPTION
As reported in [Bugzilla bug 1443630](https://bugzilla.mozilla.org/show_bug.cgi?id=1443630), 8+year old versions of MooTools conditionally define an incompatible version of `Array.prototype.flatten`. See [mootools/mootools-core/Source/Core/Core.js](https://github.com/mootools/mootools-core/blame/604a893ca91865d3af5875459afee366ecc5b21c/Source/Core/Core.js#L52) for the responsible code. In an attempt to turn a negative situation into a positive one, I am taking this opportunity to rename `flatten` to `smoosh`.

![bunnies](https://media.giphy.com/media/1VKi2xud4qsrS/giphy.gif)