### PR TITLE
Generalize flatMap to drop flatten

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -1,5 +1,5 @@
 <pre class=metadata>
-title: Array.prototype.flatMap &amp; Array.prototype.flatten
+title: Array.prototype.flatMap
 toc: false
 stage: 3
 contributors: Michael Ficarra and Brian Terlson
@@ -7,8 +7,7 @@ contributors: Michael Ficarra and Brian Terlson
 
 <emu-intro id="intro">
   <h1>Introduction</h1>
-  <p>`Array.prototype.flatten` returns a new array with all sub-array elements concatted into it recursively up to the specified depth.</p>
-  <p>`Array.prototype.flatMap` first maps each element using a mapping function, then flattens the result into a new array. It is identical to a map followed by a flatten, but flatMap is quite often useful and merging both into one method is slightly more efficient.</p>
+  <p>`Array.prototype.flatMap` returns a new array with all sub-array elements (up to a depth limit) recursively added into it, optionally first mapping each element using a function. It is identical to a map followed by a flatten, but flatMap is quite often useful and merging both into one method is slightly more efficient.</p>
 </emu-intro>
 
 <emu-clause id="sec-Array.prototype.flatMap">
@@ -33,20 +32,6 @@ contributors: Michael Ficarra and Brian Terlson
       1. Set _T_ to _thisArg_.
     1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
     1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, _depthNum_, _mapperFunction_, _T_).
-    1. Return _A_.
-  </emu-alg>
-</emu-clause>
-<emu-clause id="sec-Array.prototype.flatten">
-  <h1>Array.prototype.flatten( [ _depth_ ] )</h1>
-  <p>When the `flatten` method is called with zero or one arguments, the following steps are taken:</p>
-  <emu-alg>
-    1. Let _O_ be ? ToObject(*this* value).
-    1. Let _sourceLen_ be ? ToLength(? Get(_O_, `"length"`)).
-    1. Let _depthNum_ be 1.
-    1. If _depth_ is not *undefined*, then
-      1. Set _depthNum_ to ? ToInteger(_depth_).
-    1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
-    1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, _depthNum_).
     1. Return _A_.
   </emu-alg>
 </emu-clause>

--- a/proposal.html
+++ b/proposal.html
@@ -8,19 +8,31 @@ contributors: Michael Ficarra and Brian Terlson
 <emu-intro id="intro">
   <h1>Introduction</h1>
   <p>`Array.prototype.flatten` returns a new array with all sub-array elements concatted into it recursively up to the specified depth.</p>
-  <p>`Array.prototype.flatMap` first maps each element using a mapping function, then flattens the result into a new array. It is identical to a map followed by a flatten of depth 1, but flatMap is quite often useful and merging both into one method is slightly more efficient.</p>
+  <p>`Array.prototype.flatMap` first maps each element using a mapping function, then flattens the result into a new array. It is identical to a map followed by a flatten, but flatMap is quite often useful and merging both into one method is slightly more efficient.</p>
 </emu-intro>
 
 <emu-clause id="sec-Array.prototype.flatMap">
-  <h1>Array.prototype.flatMap ( _mapperFunction_ [ , _thisArg_ ] )</h1>
-  <p>When the `flatMap` method is called with one or two arguments, the following steps are taken:</p>
+  <h1>Array.prototype.flatMap ( [ _depth_ ] [ , _mapperFunction_ [ , _thisArg_ ] ] )</h1>
+  <p>When the `flatMap` method is called with one or two or three arguments, the following steps are taken:</p>
   <emu-alg>
     1. Let _O_ be ? ToObject(*this* value).
     1. Let _sourceLen_ be ? ToLength(? Get(_O_, `"length"`)).
-    1. If IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
-    1. If _thisArg_ is present, let _T_ be _thisArg_; else let _T_ be *undefined*.
+    1. Let _depthNum_ be 1.
+    1. Let _T_ be *undefined*.
+    1. If IsCallable(_depth_) is *true*, then
+      1. Set _thisArg_ to _mapperFunction_.
+      1. Set _mapperFunction_ to _depth_.
+      1. Set _depth_ to *undefined*.
+    1. If _depth_ is not *undefined*, then
+      1. Set _depthNum_ to ? ToInteger(_depth_).
+    1. If _mapperFunction_ is not *undefined*, then
+	  1. If IsCallable(_mapperFunction_) is *false*, throw a *TypeError* exception.
+    1. Else _mapperFunction_ must be *undefined*,
+      1. If _thisArg_ is not *undefined*, throw a *TypeError* exception.
+    1. If _thisArg_ is not *undefined*, then
+      1. Set _T_ to _thisArg_.
     1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
-    1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, 1, _mapperFunction_, _T_).
+    1. Perform ? FlattenIntoArray(_A_, _O_, _sourceLen_, 0, _depthNum_, _mapperFunction_, _T_).
     1. Return _A_.
   </emu-alg>
 </emu-clause>

--- a/proposal.html
+++ b/proposal.html
@@ -37,7 +37,7 @@ contributors: Michael Ficarra and Brian Terlson
 </emu-clause>
 
 <emu-clause id="sec-FlattenIntoArray" aoid="FlattenIntoArray">
-  <h1>FlattenIntoArray(_target_, _source_, _sourceLen_, _start_, _depth_ [ , _mapperFunction_, _thisArg_ ])</h1>
+  <h1>FlattenIntoArray(_target_, _source_, _sourceLen_, _start_, _depth_ , _mapperFunction_, _thisArg_ )</h1>
   <emu-alg>
     1. Let _targetIndex_ be _start_.
     1. Let _sourceIndex_ be 0.
@@ -46,8 +46,7 @@ contributors: Michael Ficarra and Brian Terlson
       1. Let _exists_ be ? HasProperty(_source_, _P_).
       1. If _exists_ is *true*, then
         1. Let _element_ be ? Get(_source_, _P_).
-        1. If _mapperFunction_ is present, then
-          1. Assert: _thisArg_ is present.
+        1. If _mapperFunction_ is not *undefined*, then
           1. Set _element_ to ? Call(_mapperFunction_, _thisArg_ , &laquo; _element_, _sourceIndex_, _source_ &raquo;).
         1. Let _shouldFlatten_ be *false*.
         1. If _depth_ &gt; 0, then


### PR DESCRIPTION
Alternative to #56.

Adds an optional _depth_ parameter to `flatMap`, specifies the necessary argument hockey, and abandons `flatten` because [MooTools already homesteaded it](https://bugzilla.mozilla.org/show_bug.cgi?id=1443630).